### PR TITLE
Add ZIP elasticsearch repository for IT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,17 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>elasticsearch-releases-zip</id>
+            <url>http://download.elastic.co/elasticsearch/release/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
When running IT, maven tries to locate:

```xml
<artifactItem>
    <groupId>org.elasticsearch.plugin</groupId>
    <artifactId>license</artifactId>
    <version>${elasticsearch.version}</version>
    <type>zip</type>
    <overWrite>true</overWrite>
</artifactItem>
```

We need to add another repository to be able to find those ZIP files as they are not published in the "maven" repo.