### PR TITLE
5.5

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -8,7 +8,8 @@ This is the follow-on to the custom realm plugin for Shield; examples of that ca
 p. Please make sure to use the correct branch of this repository that corresponds to the version of elasticsearch that you are developing the extension for.
 
 |_. Branch |_.  Elasticsearch Version   |
-| "master":https://github.com/elastic/shield-custom-realm-example                          | 5.4.x  |
+| "master":https://github.com/elastic/shield-custom-realm-example                          | 5.5.x  |
+| "5.5":https://github.com/elastic/shield-custom-realm-example/tree/5.5                    | 5.5.x  |
 | "5.4":https://github.com/elastic/shield-custom-realm-example/tree/5.4                    | 5.4.x  |
 | "5.3":https://github.com/elastic/shield-custom-realm-example/tree/5.3                    | 5.3.x  |
 | "5.2":https://github.com/elastic/shield-custom-realm-example/tree/5.2                    | 5.2.x  |

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ import org.elasticsearch.gradle.MavenFilteringHack
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
-version = '5.4.2'
+version = '5.5.0'
 
 buildscript {
   repositories {
@@ -32,7 +32,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:5.4.2"
+    classpath "org.elasticsearch.gradle:build-tools:5.5.0"
   }
 }
 

--- a/src/main/java/org/elasticsearch/example/realm/CustomCachingRealm.java
+++ b/src/main/java/org/elasticsearch/example/realm/CustomCachingRealm.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.example.realm;
 
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.xpack.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.security.user.User;
 import org.elasticsearch.xpack.security.authc.RealmConfig;
 import org.elasticsearch.xpack.security.authc.support.CachingRealm;
-import org.elasticsearch.xpack.security.authc.support.SecuredString;
 import org.elasticsearch.xpack.security.authc.support.UsernamePasswordToken;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,11 +64,11 @@ public class CustomCachingRealm extends CustomRealm implements CachingRealm {
         if (userHolder == null || userHolder.password == null) {
             User user = super.authenticate(token);
             if (user != null) {
-                userHolder = new UserHolder(token.credentials().copyChars(), user);
+                userHolder = new UserHolder(token.credentials().getChars(), user);
                 cache.put(token.principal(), userHolder);
                 return user;
             }
-        } else if (SecuredString.constantTimeEquals(token.credentials().internalChars(), userHolder.password)) {
+        } else if (token.credentials().equals(new SecureString(userHolder.password))) {
             return userHolder.user;
         }
         return null;

--- a/src/main/java/org/elasticsearch/example/realm/CustomCachingRealm.java
+++ b/src/main/java/org/elasticsearch/example/realm/CustomCachingRealm.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.example.realm;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.xpack.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.security.user.User;
@@ -72,6 +73,16 @@ public class CustomCachingRealm extends CustomRealm implements CachingRealm {
             return userHolder.user;
         }
         return null;
+    }
+
+    /* this is the provided implementation from org.elasticsearch.xpack.security.authc.Realm */
+    @Override
+    public void authenticate(AuthenticationToken token, ActionListener<User> listener) {
+        try {
+            listener.onResponse(authenticate(token));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 
     /**

--- a/src/main/java/org/elasticsearch/example/realm/CustomRealm.java
+++ b/src/main/java/org/elasticsearch/example/realm/CustomRealm.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.example.realm;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -125,6 +126,16 @@ public class CustomRealm extends Realm{
             return new User(actualUser, info.roles);
         }
         return null;
+    }
+
+    /* this is the provided implementation from org.elasticsearch.xpack.security.authc.Realm */
+    @Override
+    public void authenticate(AuthenticationToken token, ActionListener<User> listener) {
+        try {
+            listener.onResponse(authenticate(token));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 
     /**

--- a/src/main/java/org/elasticsearch/example/realm/CustomRealm.java
+++ b/src/main/java/org/elasticsearch/example/realm/CustomRealm.java
@@ -27,7 +27,7 @@ import org.elasticsearch.xpack.security.user.User;
 import org.elasticsearch.xpack.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.security.authc.Realm;
 import org.elasticsearch.xpack.security.authc.RealmConfig;
-import org.elasticsearch.xpack.security.authc.support.SecuredString;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.xpack.security.authc.support.UsernamePasswordToken;
 
 import java.util.Collections;
@@ -102,7 +102,7 @@ public class CustomRealm extends Realm{
         if (user != null) {
             String password = threadContext.getHeader(PW_HEADER);
             if (password != null) {
-                return new UsernamePasswordToken(user, new SecuredString(password.toCharArray()));
+                return new UsernamePasswordToken(user, new SecureString(password.toCharArray()));
             }
         }
         return null;
@@ -121,7 +121,7 @@ public class CustomRealm extends Realm{
         final String actualUser = token.principal();
         final InfoHolder info = usersMap.get(actualUser);
 
-        if (info != null && SecuredString.constantTimeEquals(token.credentials(), info.password)) {
+        if (info != null && token.credentials().equals(info.password)) {
             return new User(actualUser, info.roles);
         }
         return null;

--- a/src/test/java/org/elasticsearch/example/realm/CustomCachingRealmTests.java
+++ b/src/test/java/org/elasticsearch/example/realm/CustomCachingRealmTests.java
@@ -36,12 +36,12 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Unit tests for the CustomCachingRealm
  */
 public class CustomCachingRealmTests extends ESTestCase {
-
-    private User first = null;
 
     public void testAuthenticateWithCachedValue() {
         //setup
@@ -54,23 +54,24 @@ public class CustomCachingRealmTests extends ESTestCase {
         CustomCachingRealm realm = new CustomCachingRealm(new RealmConfig("test", realmSettings, globalSettings,
                 new Environment(globalSettings), new ThreadContext(globalSettings)));
 
+        final AtomicReference<User> first = new AtomicReference<>();
+
         // authenticate john
         UsernamePasswordToken token = new UsernamePasswordToken("john", new SecureString(new char[] { 'd', 'o', 'e'}));
         realm.authenticate(token, ActionListener.wrap(user -> {
             assertThat(user, notNullValue());
             assertThat(user.roles(), arrayContaining("user"));
             assertThat(user.principal(), equalTo("john"));
-            CustomCachingRealmTests.this.first = user;
+            first.set(user);
         }, e -> fail("Failed with exception: " + e.getMessage())));
 
         // authenticate john again and we should be returned the same user object
-        User user1 = realm.authenticate(token);
         realm.authenticate(token, ActionListener.wrap(user -> {
-            assertThat(user, sameInstance(first));
+            assertThat(user, sameInstance(first.get()));
         }, e -> fail("Failed with exception: " + e.getMessage())));
 
         // modify the cache entry with a changed password
-        CustomCachingRealm.UserHolder holder = new CustomCachingRealm.UserHolder("changed".toCharArray(), first);
+        CustomCachingRealm.UserHolder holder = new CustomCachingRealm.UserHolder("changed".toCharArray(), first.get());
         realm.putInCache("john", holder);
 
         // try to authenticate again with the old password
@@ -81,7 +82,7 @@ public class CustomCachingRealmTests extends ESTestCase {
         // authenticate with new password
         token = new UsernamePasswordToken("john", new SecureString("changed".toCharArray()));
         realm.authenticate(token, ActionListener.wrap(user -> {
-            assertThat(user, sameInstance(first));
+            assertThat(user, sameInstance(first.get()));
         }, e -> fail("Failed with exception: " + e.getMessage())));
 
         // clear the cache
@@ -100,8 +101,8 @@ public class CustomCachingRealmTests extends ESTestCase {
         token = new UsernamePasswordToken("john", new SecureString(new char[] { 'd', 'o', 'e'}));
         realm.authenticate(token, ActionListener.wrap(user -> {
             assertThat(user, not(nullValue()));
-            assertThat(user, not(sameInstance(first)));
-            assertThat(user, equalTo(first));
+            assertThat(user, not(sameInstance(first.get())));
+            assertThat(user, equalTo(first.get()));
         }, e -> fail("Failed with exception: " + e.getMessage())));
     }
 }

--- a/src/test/java/org/elasticsearch/example/realm/CustomCachingRealmTests.java
+++ b/src/test/java/org/elasticsearch/example/realm/CustomCachingRealmTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.security.user.User;
 import org.elasticsearch.xpack.security.authc.RealmConfig;
-import org.elasticsearch.xpack.security.authc.support.SecuredString;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.xpack.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.test.ESTestCase;
 
@@ -52,7 +52,7 @@ public class CustomCachingRealmTests extends ESTestCase {
                 new Environment(globalSettings), new ThreadContext(globalSettings)));
 
         // authenticate john
-        UsernamePasswordToken token = new UsernamePasswordToken("john", new SecuredString(new char[] { 'd', 'o', 'e'}));
+        UsernamePasswordToken token = new UsernamePasswordToken("john", new SecureString(new char[] { 'd', 'o', 'e'}));
         final User user = realm.authenticate(token);
         assertThat(user, notNullValue());
         assertThat(user.roles(), arrayContaining("user"));
@@ -71,7 +71,7 @@ public class CustomCachingRealmTests extends ESTestCase {
         assertThat(user1, nullValue());
 
         // authenticate with new password
-        token = new UsernamePasswordToken("john", new SecuredString("changed".toCharArray()));
+        token = new UsernamePasswordToken("john", new SecureString("changed".toCharArray()));
         user1 = realm.authenticate(token);
         assertThat(user1, sameInstance(user));
 
@@ -87,7 +87,7 @@ public class CustomCachingRealmTests extends ESTestCase {
         assertThat(user1, nullValue());
 
         // authenticate with correct password should work
-        token = new UsernamePasswordToken("john", new SecuredString(new char[] { 'd', 'o', 'e'}));
+        token = new UsernamePasswordToken("john", new SecureString(new char[] { 'd', 'o', 'e'}));
         user1 = realm.authenticate(token);
         assertThat(user1, not(nullValue()));
         assertThat(user1, not(sameInstance(user)));

--- a/src/test/java/org/elasticsearch/example/realm/CustomRealmTests.java
+++ b/src/test/java/org/elasticsearch/example/realm/CustomRealmTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.security.user.User;
 import org.elasticsearch.xpack.security.authc.RealmConfig;
-import org.elasticsearch.xpack.security.authc.support.SecuredString;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.xpack.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.test.ESTestCase;
 
@@ -52,14 +52,14 @@ public class CustomRealmTests extends ESTestCase {
                 new Environment(globalSettings), new ThreadContext(globalSettings)));
 
         // authenticate john
-        UsernamePasswordToken token = new UsernamePasswordToken("john", new SecuredString(new char[] { 'd', 'o', 'e'}));
+        UsernamePasswordToken token = new UsernamePasswordToken("john", new SecureString(new char[] { 'd', 'o', 'e'}));
         User user = realm.authenticate(token);
         assertThat(user, notNullValue());
         assertThat(user.roles(), arrayContaining("user"));
         assertThat(user.principal(), equalTo("john"));
 
         // authenticate jane
-        token = new UsernamePasswordToken("jane", new SecuredString(new char[] { 't', 'e', 's', 't'}));
+        token = new UsernamePasswordToken("jane", new SecureString(new char[] { 't', 'e', 's', 't'}));
         user = realm.authenticate(token);
         assertThat(user, notNullValue());
         assertThat(user.roles(), arrayContaining("user", "admin"));
@@ -79,7 +79,7 @@ public class CustomRealmTests extends ESTestCase {
         CustomRealm realm = new CustomRealm(new RealmConfig("test", realmSettings, globalSettings,
                 new Environment(globalSettings), new ThreadContext(globalSettings)));
         UsernamePasswordToken token =
-                new UsernamePasswordToken("john1", new SecuredString(randomAlphaOfLengthBetween(4, 16).toCharArray()));
+                new UsernamePasswordToken("john1", new SecureString(randomAlphaOfLengthBetween(4, 16).toCharArray()));
         User user = realm.authenticate(token);
         assertThat(user, nullValue());
     }


### PR DESCRIPTION
I thought it would be better to submit a PR than push. Not sure if right call...
@tvernum the `authenticate(AuthenticationToken token, ActionListener<User> listener)` call is already implemented in `org.elasticsearch.xpack.security.authc.Realm` for 5.5: https://github.com/elastic/x-pack-elasticsearch/blob/5.5/plugin/src/main/java/org/elasticsearch/xpack/security/authc/Realm.java